### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -42,6 +46,12 @@ stages:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of 3dengine, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: the `unix` branch of the Makefile is arch-neutral and the core is portable C++ on top of GL/GLES.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include.

Verified natively on aarch64 (postmarketOS on a Snapdragon 670 / Adreno 618 Chromebook, glibc, GCC 15): `make platform=unix` builds clean with no source changes, producing `3dengine_libretro.so` (ELF 64-bit ARM aarch64). Loading this repo's own `assets/example-model/box.obj` in RetroArch 1.22.2 renders the textured scene correctly through the GL (freedreno) driver at 58.2 fps, 320x240.
