### PR TITLE
ci: build for Windows and macOS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,22 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Windows 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-x64-mingw.yml'
+
+  # Windows 32-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-i686-mingw.yml'
+
+  # MacOS 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-x64.yml'
+
+  # MacOS ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-arm64.yml'
+
   # Linux ARM 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-aarch64.yml'
@@ -42,6 +58,30 @@ stages:
 ##############################################################################
 #
 ################################### DESKTOPS #################################
+# Windows 64-bit
+libretro-build-windows-x64:
+  extends:
+    - .libretro-windows-x64-mingw-make-default
+    - .core-defs
+
+# Windows 32-bit
+libretro-build-windows-i686:
+  extends:
+    - .libretro-windows-i686-mingw-make-default
+    - .core-defs
+
+# MacOS 64-bit
+libretro-build-osx-x64:
+  extends:
+    - .libretro-osx-x64-make-default
+    - .core-defs
+
+# MacOS ARM 64-bit
+libretro-build-osx-arm64:
+  extends:
+    - .libretro-osx-arm64-make-default
+    - .core-defs
+
 # Linux 64-bit
 libretro-build-linux-x64:
   extends:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,22 @@ else ifneq (,$(findstring osx,$(platform)))
    INCFLAGS += -Iinclude/compat
    OSXVER = `sw_vers -productVersion | cut -d. -f 2`
    OSX_LT_MAVERICKS = `(( $(OSXVER) <= 9)) && echo "YES"`
-   fpic += -fPIC -mmacosx-version-min=10.1
+   # 10.1 predates arm64 by two decades; it was being passed on every
+   # macOS build even though OSX_LT_MAVERICKS was computed and never read.
+   ifeq ($(OSX_LT_MAVERICKS),"YES")
+      MINVERSION = -mmacosx-version-min=10.1
+   endif
+   fpic += -fPIC $(MINVERSION)
+
+   # The buildbot's arm64 job cross-compiles and hands the target triple
+   # and SDK down in these; without them the build follows the host and
+   # the job's own lipo check rejects the result.
+   ifeq ($(CROSS_COMPILE),1)
+      TARGET_RULE = -target $(LIBRETRO_APPLE_PLATFORM) -isysroot $(LIBRETRO_APPLE_ISYSROOT)
+      CFLAGS   += $(TARGET_RULE)
+      CXXFLAGS += $(TARGET_RULE)
+      LDFLAGS  += $(TARGET_RULE)
+   endif
 
 else ifneq (,$(findstring armv,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
The buildbot publishes this core for four of the thirty-five platforms it knows about — three Linux ones and webOS — even though the Makefile has carried Windows and macOS branches all along. Nobody had wired them up.

### Windows

Needs nothing but the jobs. The templates build with `platform=win64` and `win32`, neither of which matches anything earlier in the chain, so both fall through to the Windows branch at the end and produce a `.dll` against `-lopengl32`.

### macOS

Needed the Makefile fixing first, in two ways that only show up when the buildbot drives it:

- `-mmacosx-version-min=10.1` was passed on **every** macOS build. The branch computes `OSX_LT_MAVERICKS` to decide exactly that and then never reads it, so the flag went out unconditionally — and 10.1 predates arm64 by two decades. It is now gated the way the surrounding cores gate it.
- The arm64 job cross-compiles: it sets `CROSS_COMPILE` and passes the target triple and SDK path in `LIBRETRO_APPLE_PLATFORM` and `LIBRETRO_APPLE_ISYSROOT`, which this Makefile ignored. Without them the build follows the host and the job’s own `lipo` check fails it. The `CROSS_COMPILE` block is the same one `bsnes-libretro-cplusplus98` uses, which builds both macOS jobs green.

### Checks

Every platform still resolves to the right output and the Makefile parses: `win64` and `win32` give a `.dll`, `osx` a `.dylib`, `unix` an unchanged `.so`; `CROSS_COMPILE=1` injects `-target` and `-isysroot`; and the 10.1 minimum is no longer applied on a modern host. Actually building for these needs the buildbot’s toolchains, so the pipeline here is the real test.

### Not in this one

Android, iOS, tvOS and emscripten have Makefile branches here too, and `jni/` is present for the first. They are worth adding as well, but this is a 3D demo core whose GLES paths may not have been built in years — so this starts with the two that need no new code, and the pipeline can say whether the rest are worth a second round.